### PR TITLE
Fix VC order displaying differently in chrome/firefox

### DIFF
--- a/public/javascripts/compileAnalysis.js
+++ b/public/javascripts/compileAnalysis.js
@@ -444,20 +444,19 @@ function selectVC(lineNum){
 }
 
 function sortByIdAndLine(a, b){
-    var line1 = a.line;
-    var line2 = b.line;
-    
+    var line1 = parseInt(a.line,10);
+    var line2 = parseInt(b.line,10);
+
     var id1 = a.vcID;
     var id2 = b.vcID;
-    
-    return (((typeof line1 === "undefined") || (typeof line2 === "undefined"))? 1 : (
-        (line1 != line2) ? (
-            (line1 < line2) ? -1 : ((line1 > line2) ? 1 : 0)
-        ) : (
-            (id1 < id2) ? -1 : ((id1 > id2) ? 1 : 0)
-        )
-        
-    ));
-    //return ((typeof line1 === "undefined") ? 1 : ((line1 < line2) ? -1 : ((line1 > line2) ? 1 : 0)));
+    if(isNaN(line1) || isNaN(line2)) {
+       if(isNaN(line1)) return 1;
+       if(isNaN(line2)) return -1;
+    }
+    if(line1 < line2) return -1;
+    if(line1 > line2) return 1;
+    if(id1 < id2) return -1;
+    if(id1 > id2) return 1;
+    return 0;
 }
 

--- a/public/javascripts/editor.js
+++ b/public/javascripts/editor.js
@@ -1566,21 +1566,20 @@ function getVcSteps(rawVCs){
 }
 
 function sortByIdAndLine(a, b){
-    var line1 = a.line;
-    var line2 = b.line;
-    
+    var line1 = parseInt(a.line,10);
+    var line2 = parseInt(b.line,10);
+
     var id1 = a.vcID;
     var id2 = b.vcID;
-    
-    return (((typeof line1 === "undefined") || (typeof line2 === "undefined"))? 1 : (
-        (line1 != line2) ? (
-            (line1 < line2) ? -1 : ((line1 > line2) ? 1 : 0)
-        ) : (
-            (id1 < id2) ? -1 : ((id1 > id2) ? 1 : 0)
-        )
-        
-    ));
-    //return ((typeof line1 === "undefined") ? 1 : ((line1 < line2) ? -1 : ((line1 > line2) ? 1 : 0)));
+    if(isNaN(line1) || isNaN(line2)) {
+       if(isNaN(line1)) return 1;
+       if(isNaN(line2)) return -1;
+    }
+    if(line1 < line2) return -1;
+    if(line1 > line2) return 1;
+    if(id1 < id2) return -1;
+    if(id1 > id2) return 1;
+    return 0;
 }
 
 /*$.ui.plugin.add("resizable", "alsoResizeReverse", {


### PR DESCRIPTION
The old sortByIdAndLine function was broken and caused some issues.
Notably, firefox and chrome gave different results so the VCs
displayed in a significantly different order. This made cooperating
frustrating because going through them in "order" had no meaning to
coding partners.

An example of this behavior (which uses vc data derived from a real
resolve session) can be seen here: https://gist.github.com/euank/5450654

I also parsed the line numbers as integers and changed the ternary
operators (which caused the problem in the first place I think) into
more readable conditions.