### PR TITLE
Java Import Changes on Backend

### DIFF
--- a/app/compiler/WsListener.java
+++ b/app/compiler/WsListener.java
@@ -1,8 +1,8 @@
 package compiler;
 
-import edu.clemson.cs.r2jt.proving2.Metrics;
-import edu.clemson.cs.r2jt.proving2.ProverListener;
-import edu.clemson.cs.r2jt.proving2.model.PerVCProverModel;
+import edu.clemson.cs.r2jt.rewriteprover.Metrics;
+import edu.clemson.cs.r2jt.rewriteprover.ProverListener;
+import edu.clemson.cs.r2jt.rewriteprover.model.PerVCProverModel;
 
 /**
  * Created with IntelliJ IDEA.

--- a/app/controllers/CompilerSocket.java
+++ b/app/controllers/CompilerSocket.java
@@ -5,7 +5,7 @@ import compiler.*;
 import edu.clemson.cs.r2jt.ResolveCompiler;
 import edu.clemson.cs.r2jt.data.MetaFile;
 import edu.clemson.cs.r2jt.data.ModuleKind;
-import edu.clemson.cs.r2jt.proving2.ProverListener;
+import edu.clemson.cs.r2jt.rewriteprover.ProverListener;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;


### PR DESCRIPTION
Instead of having proving and proving2 packages, Dan has collapsed both into a package called rewriteprover. This requires us to change the imports to reflect prover package name changes inside RESOLVE compiler. 